### PR TITLE
Support for addHtmlPreModifiers/addHtmlPostModifiers, dynamic arguments

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -173,9 +173,11 @@ class Message {
   public static function improveArrayOutput(array $array_items) {
     // Remove any objects from the debug output.
     foreach ($array_items as $key => &$array_item) {
-      foreach ($array_item as $sub_key => $sub_array_item) {
-        if (is_object($sub_array_item)) {
-          unset($array_item[$sub_key]);
+      if (is_array($array_item)) {
+        foreach ($array_item as $sub_key => $sub_array_item) {
+          if (is_object($sub_array_item)) {
+            unset($array_item[$sub_key]);
+          }
         }
       }
     }

--- a/src/Modifier/Modifier.php
+++ b/src/Modifier/Modifier.php
@@ -12,7 +12,12 @@ use Drupal\migration_tools\Message;
 abstract class Modifier {
   public $modifiers = [];
   public $preModifiers = [];
+  public $htmlPreModifiers = [];
+  public $htmlPostModifiers = [];
   public $queryPath;
+
+  // HTML contents for html modifiers.
+  protected $html;
 
   /**
    * Constructor.
@@ -20,7 +25,17 @@ abstract class Modifier {
    * @param object $query_path
    *   The query path object by reference.
    */
-  public function __construct(&$query_path) {
+  public function __construct(&$query_path = NULL) {
+    $this->queryPath = $query_path;
+  }
+
+  /**
+   * Set Query Path.
+   *
+   * @param object $query_path
+   *   Query Path.
+   */
+  public function setQueryPath(&$query_path) {
     $this->queryPath = $query_path;
   }
 
@@ -69,6 +84,53 @@ abstract class Modifier {
   }
 
   /**
+   * Add a new method to be called on HTML prior to queryPath.
+   *
+   * Runs before any built-in HTML modifications are done.
+   *
+   * @param string $method_name
+   *   The name of the method to call.
+   * @param array $arguments
+   *   (optional) An array of arguments to be passed to the $method. Defaults
+   *   to an empty array.
+   *
+   * @return Modifier
+   *   Returns $this to allow chaining.
+   */
+  public function addHtmlPreModifier($method_name, array $arguments = []) {
+    // @todo Maybe we should validate the method names here?
+    $this->htmlPreModifiers[] = [
+      'method_name' => $method_name,
+      'arguments' => $arguments,
+    ];
+
+    return $this;
+  }
+
+  /**
+   * Add a new method to be called on HTML prior to queryPath.
+   *
+   * Runs after any built-in HTML modifications are done.
+   *
+   * @param string $method_name
+   *   The name of the method to call.
+   * @param array $arguments
+   *   (optional) An array of arguments to be passed to the $method. Defaults
+   *   to an empty array.
+   *
+   * @return Modifier
+   *   Returns $this to allow chaining.
+   */
+  public function addHtmlPostModifier($method_name, array $arguments = []) {
+    // @todo Maybe we should validate the method names here?
+    $this->htmlPostModifiers[] = [
+      'method_name' => $method_name,
+      'arguments' => $arguments,
+    ];
+
+    return $this;
+  }
+  /**
    * Runs the modifiers and reports which were successful.
    *
    * @param bool $pre
@@ -96,4 +158,36 @@ abstract class Modifier {
     Message::makeSummary($alter_log, $total_requested, 'Modifiers applied successfully:');
   }
 
+  /**
+   * Runs the modifiers and reports which were successful.
+   *
+   * @param string $html
+   *   HTML contents to run modifiers on.
+   *
+   * @param bool $pre
+   *   If TRUE, runs before any other built-in HTML modifications.
+   *
+   * @return string
+   *   Modified HTML.
+   */
+  public function runHtmlModifiers($html, $pre = TRUE) {
+    $this->html = $html;
+    $modifiers = $pre ? $this->htmlPreModifiers : $this->htmlPostModifiers;
+    $alter_log = [];
+    $total_requested = count($modifiers);
+    foreach ($modifiers as $key => $modifier) {
+      if (!method_exists($this, $modifier['method_name'])) {
+        Message::make('The modifier method @method does not exist and was skipped.', ['@method' => $modifier['method_name']], Message::DEBUG);
+      }
+
+      $count = call_user_func_array([$this, $modifier['method_name']], $modifier['arguments']);
+      // Record only what worked.
+      if ($count) {
+        $args = implode(', ', $modifier['arguments']);
+        $alter_log[] = "x{$count} {$modifier['method_name']}({$args}) ";
+      }
+    }
+    Message::makeSummary($alter_log, $total_requested, 'HTML Modifiers applied successfully:');
+    return $this->html;
+  }
 }

--- a/src/Modifier/ModifyHtml.php
+++ b/src/Modifier/ModifyHtml.php
@@ -337,4 +337,28 @@ class ModifyHtml extends Modifier {
     self::cleanExtraTags($search, $selector, $where);
   }
 
+  /**
+   * Replace string in HTML.
+   *
+   * @param string $search
+   *   Search pattern
+   * @param string $replace
+   *   Replacement pattern
+   * @param bool $case_insensitive
+   *   If TRUE, uses case-insensitive replacement. Ignored if regex = TRUE
+   * @param bool $regex
+   *   If TRUE, uses regex with preg_replace.
+   */
+  public function replaceString($search, $replace, $case_insensitive = FALSE, $regex = FALSE) {
+    if ($regex) {
+      $this->html = preg_replace($search, $replace, $this->html);
+    }
+    elseif ($case_insensitive) {
+      $this->html = str_ireplace($search, $replace, $this->html);
+    }
+    else {
+      $this->html = str_replace($search, $replace, $this->html);
+    }
+  }
+
 }

--- a/src/Obtainer/ObtainLinkFile.php
+++ b/src/Obtainer/ObtainLinkFile.php
@@ -74,6 +74,7 @@ class ObtainLinkFile extends ObtainLink {
     if ($links) {
       foreach ($links as $key => $link) {
         $extension = strtolower(pathinfo($link['href'], PATHINFO_EXTENSION));
+        $extension = preg_replace('/#.*/', '', $extension);
         $link_domain = strtolower(parse_url($link['base_uri'], PHP_URL_HOST));
         if (!in_array($extension, $file_extensions)) {
           unset($links[$key]);


### PR DESCRIPTION
https://www.drupal.org/project/migration_tools/issues/2953486#comment-12543558

This allows the source parser to be instantiated without HTML specified and then set the source parser's HTML after modifiers are run. Also add ability to use jobs to set a variable, then use that variable as a dynamic argument in another job's arguments. Adds replaceString modifier

Example YML:
```
  fields:
    -
      name: person_id
      label: 'Get Name'
      obtainer: ObtainHTML
      jobs:
        -
          job: addSearch
          method: findSelector
          arguments: [ '.person-id' ]
    -
      name: person_details
      label: 'Get Persons Details By Class'
      obtainer: ObtainHTML
      jobs:
        -
          job: addSearch
          method: findSelector
          arguments: [ '.@person_id' ]

  modifiers:
    -
      modifier: addHtmlPreModifier
      method: replaceString
      arguments: [ '<p>', '<div>', TRUE ]
    -
      modifier: addHtmlPreModifier
      method: replaceString
      arguments: [ '</p>', '</div>', TRUE ]
    -
      modifier: addHtmlPostModifier
      method: replaceString
      arguments: [ '/<\/a><\/a>/i', '</a>', TRUE, TRUE ]
```
